### PR TITLE
New Type Parser 

### DIFF
--- a/enforce/decorators.py
+++ b/enforce/decorators.py
@@ -1,10 +1,17 @@
 import sys
 import inspect
 from functools import wraps
+import typing
 from typing import get_type_hints, Callable, Any
 
 from .exceptions import RuntimeTypeError
 
+
+def check_iterability(vartype: typing.TypeVar, hint: typing.TypeVar):
+    check_iterable = issubclass(vartype, typing.Iterable)
+    check_not_str  = not issubclass(vartype, str)
+    check_not_Any  = hint != typing.Any
+    return check_iterable and check_not_str and check_not_Any
 
 def runtime_validation(func: Callable) -> Callable:
     """
@@ -13,6 +20,28 @@ def runtime_validation(func: Callable) -> Callable:
     """
     error_message = "Argument '{0}' ('{1}') was not of type {2}. Actual type was {3}."
     return_error_message = "Return value '{0}' was not of type {1}. Actual type was {2}."
+
+    def check_recursive_types(types: typing.Iterable[typing.Tuple[str, typing.Any, typing.Any]]) -> typing.Tuple[bool, str]:
+        """
+        Recursively checks types of some iterable.
+
+        Note, we don't count strings as iterable types
+        (possible up for debate? can't think of a situation where you'd want to recurse on str types)
+        """
+        typecheck = True
+        exception_text = ''
+        for name, variable, hint in types:
+            vartype = type(variable)
+            isiterable = check_iterability(vartype, hint)
+            if not issubclass(vartype, hint):
+                typecheck = False
+                exception_text += error_message.format(name, str(variable), hint, vartype) + '\n'
+            if isiterable:
+                # If we're currently examining an iterable type
+                # we need to recurse
+                print('\n{} => {} => {}'.format(hint, vartype, variable))
+
+        return typecheck, exception_text
 
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -23,8 +52,7 @@ def runtime_validation(func: Callable) -> Callable:
 
         Note on expected behavior: If type is not specified, we assume that it's None.
         """
-        exception_text = ''
-
+        # Setup initial types/hinting
         binded_arguments = inspect.signature(func).bind(*args, **kwargs)
 
         argument_hints = get_type_hints(func)
@@ -32,25 +60,24 @@ def runtime_validation(func: Callable) -> Callable:
 
         if return_hint is None:
             return_hint = type(None)
-        
-        for name, hint in argument_hints.items():
-            if hint is None:
-                hint = type(None)
-            argument = binded_arguments.arguments.get(name)
-            argument_type = type(argument)
-            if not issubclass(argument_type, hint):
-                exception_text += error_message.format(name, str(argument), hint, argument_type) + '\n'
 
-        if exception_text:
+        # check argument types
+        types = [(name, binded_arguments.arguments.get(name), hint)
+                 for name, hint in argument_hints.items()]
+        typecheck, exception_text = (check_recursive_types(types))
+
+        if not typecheck:
             exception_text = exception_text[:-1]
             raise RuntimeTypeError(exception_text)
 
+        # check return type
         result = func(*args, **kwargs)
         return_type = type(result)
 
         if not issubclass(return_type, return_hint):
             raise RuntimeTypeError(return_error_message.format(str(result), return_hint, return_type))
 
+        # If all checks pass, return result of func
         return result
 
     return wrapper

--- a/enforce/decorators.py
+++ b/enforce/decorators.py
@@ -43,12 +43,14 @@ def check_recursive_types(types: typing.Iterable[typing.Tuple[str, typing.Any, t
             names = [name] * len(variable)   # also need to have name in there for error message
             if issubclass(type(variable), dict):
                 # If we're looking at dict, need to check keys and items independently
-                subhints1 = [subhints[0]] * len(variable)
-                subhints2 = [subhints[1]] * len(variable)
-                new_typecheck1, new_exception_text1 = check_recursive_types(zip(names, variable.keys(), subhints1), msg=msg)
-                new_typecheck2, new_exception_text2 = check_recursive_types(zip(names, variable.values(), subhints2), msg=msg)
-                new_typecheck      = new_typecheck1 and new_typecheck2
-                new_exception_text = new_exception_text1 + new_exception_text2
+                lists = [variable.keys(), variable.values()]
+                new_typecheck = typecheck
+                new_exception_text = ''
+                for i in range(2):
+                    subhintsi = [subhints[i]] * len(variable)
+                    new_typechecki, new_exception_texti = check_recursive_types(zip(names, lists[i], subhintsi), msg=msg)
+                    new_typecheck &= new_typechecki
+                    new_exception_text += new_exception_texti
             else:
                 if len(subhints) == 1:    # If only 1 subhint then /possibly/ applies to all elements
                     subhints = [subhints] * len(variable)

--- a/enforce/decorators.py
+++ b/enforce/decorators.py
@@ -20,6 +20,8 @@ def runtime_validation(func: Callable) -> Callable:
         This function will be returned by the decorator. It adds type checking before triggering
         the original function and then it checks for the output type. Only then it returns the
         output of original function.
+
+        Note on expected behavior: If type is not specified, we assume that it's None.
         """
         exception_text = ''
 

--- a/enforce/decorators.py
+++ b/enforce/decorators.py
@@ -13,35 +13,44 @@ def check_iterability(vartype: typing.TypeVar, hint: typing.TypeVar):
     check_not_Any  = hint != typing.Any
     return check_iterable and check_not_str and check_not_Any
 
+
+def check_recursive_types(types: typing.Iterable[typing.Tuple[str, typing.Any, typing.Any]]) -> typing.Tuple[bool, str]:
+    """
+    Recursively checks types of some iterable.
+
+    Note, we don't count strings as iterable types
+    (possible up for debate? can't think of a situation where you'd want to recurse on str types)
+    """
+    error_message = "Argument '{0}' ('{1}') was not of type {2}. Actual type was {3}.\n"
+    typecheck = True
+    exception_text = ''
+    for name, variable, hint in types:
+        vartype = type(variable)
+        isiterable = check_iterability(vartype, hint)
+        if not issubclass(vartype, hint):
+            typecheck = False
+            exception_text += error_message.format(name, str(variable), hint, vartype)
+        if isiterable:
+            # If we're currently examining an iterable type
+            # we need to recurse
+            # __tuple_params__ defined on line 646 of typing.py
+            # Otherwise, types inherit from GenericMeta (line 878)
+            print('\n{} => {} => {}'.format(hint, vartype, variable))
+            if issubclass(hint, typing.Tuple):
+                subhints = hint.__tuple_params__
+            else:
+                subhints = hint.__parameters__
+            new_typecheck, new_exception_text = check_recursive_types(zip(variable, subhints))
+
+    return typecheck, exception_text
+
+
 def runtime_validation(func: Callable) -> Callable:
     """
     This decorator enforces runtime parameter and return value validation
     It uses the standard Python 3.5 syntax for type hinting declaration and its validation
     """
-    error_message = "Argument '{0}' ('{1}') was not of type {2}. Actual type was {3}."
     return_error_message = "Return value '{0}' was not of type {1}. Actual type was {2}."
-
-    def check_recursive_types(types: typing.Iterable[typing.Tuple[str, typing.Any, typing.Any]]) -> typing.Tuple[bool, str]:
-        """
-        Recursively checks types of some iterable.
-
-        Note, we don't count strings as iterable types
-        (possible up for debate? can't think of a situation where you'd want to recurse on str types)
-        """
-        typecheck = True
-        exception_text = ''
-        for name, variable, hint in types:
-            vartype = type(variable)
-            isiterable = check_iterability(vartype, hint)
-            if not issubclass(vartype, hint):
-                typecheck = False
-                exception_text += error_message.format(name, str(variable), hint, vartype) + '\n'
-            if isiterable:
-                # If we're currently examining an iterable type
-                # we need to recurse
-                print('\n{} => {} => {}'.format(hint, vartype, variable))
-
-        return typecheck, exception_text
 
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,4 +1,5 @@
 ﻿import unittest
+import typing
 from typing import Any, Optional
 
 import enforce
@@ -140,6 +141,31 @@ class DecoratorsTests(unittest.TestCase):
 
         self.assertEqual(original_doc, test.__doc__)
         self.assertEqual(original_name, test.__name__)
+
+    def test_working_callable_argument(self):
+        @enforce.runtime_validation
+        def foo(func: typing.Callable[[int], str], bar: int) -> str:
+            return func(bar)
+
+        try:
+            foo(lambda x: str(x), 5)
+        except enforce.exceptions.RuntimeTypeError:
+            print('Callable Argument Raised Error!')
+            raise
+
+    def test_tuple_support(self):
+        @enforce.runtime_validation
+        def test(tup: typing.Tuple[int, str, float]) -> typing.Tuple[str, int]:
+            return tup[1], tup[0]
+
+        tup = ('a', 5, 3.0)
+        try:
+            test(tup)
+            raise AssertionError
+        except enforce.exceptions.RuntimeTypeError:
+            pass
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -161,7 +161,7 @@ class DecoratorsTests(unittest.TestCase):
         tup = ('a', 5, 3.0)
         try:
             test(tup)
-            raise AssertionError
+            raise AssertionError('RuntimeTypeError should have been raised')
         except enforce.exceptions.RuntimeTypeError:
             pass
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -149,11 +149,12 @@ class DecoratorsTests(unittest.TestCase):
         def foo(func: typing.Callable[[int], str], bar: int) -> str:
             return func(bar)
 
+        foo(lambda x: str(x), 5)
+
         try:
-            foo(lambda x: str(x), 5)
+            foo(5, 7)
         except enforce.exceptions.RuntimeTypeError:
-            print('Callable Argument Raised Error!')
-            raise
+            pass
 
     def test_tuple_support(self):
         @enforce.runtime_validation

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -165,6 +165,30 @@ class DecoratorsTests(unittest.TestCase):
         except enforce.exceptions.RuntimeTypeError:
             pass
 
+    def test_list_support(self):
+        @enforce.runtime_validation
+        def test(arr: typing.List[str]) -> typing.List[str]:
+            return arr[:1]
+
+        arr = [1, 'b', 'c']
+        try:
+            test(arr)
+            raise AssertionError('RuntimeTypeError should have been raised')
+        except enforce.exceptions.RuntimeTypeError:
+            pass
+
+    def test_dict_support(self):
+        @enforce.runtime_validation
+        def test(hash: typing.Dict[str, int]) -> typing.Dict[int, str]:
+            return {value: key for key, value in hash.items()}
+
+        hash = {5: 1, 'b': 5}
+        try:
+            test(hash)
+            raise AssertionError('RuntimeTypeError should have been raised')
+        except enforce.exceptions.RuntimeTypeError:
+            pass
+
 
 
 if __name__ == '__main__':

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -30,7 +30,8 @@ class DecoratorsTests(unittest.TestCase):
         invalid_argument = 12   # Assumed to be integer
 
         error_code_1 = "Argument 'text' ('{0}') was not of type <class 'str'>. Actual type was <class 'int'>.".format(invalid_argument)
-        error_code_2 = "Return value '{0}' was not of type <class 'NoneType'>. Actual type was <class 'str'>.".format(message)
+        error_code_2 = ("Function '{0}' return value '{1}' was not of type {2}. "
+                        "Actual type was {3}.").format('test2', message, "<class 'NoneType'>", "<class 'str'>")
 
         self.assertIsNone(test(message))
 
@@ -90,7 +91,8 @@ class DecoratorsTests(unittest.TestCase):
         val_4 = {'integer': 12}
         last_4 = 1
 
-        error_message_4 = "Return value '{0}' was not of type <class 'str'>. Actual type was {1}.".format(None, type(None))
+        error_message_4= ("Function '{0}' return value '{1}' was not of type {2}. "
+                          "Actual type was {3}.").format('test2', None, "<class 'str'>", type(None))
 
         with self.assertRaises(RuntimeTypeError) as cm:
             test2(param_4, text_4, val_4, last_4)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -192,6 +192,19 @@ class DecoratorsTests(unittest.TestCase):
         except enforce.exceptions.RuntimeTypeError:
             pass
 
+    def test_recursion_slim(self):
+        @enforce.runtime_validation
+        def test(tup: typing.Tuple) -> typing.Tuple:
+            return tup
+
+        tup = (1, 2)
+        try:
+            test(tup)
+            raise AssertionError('RuntimeTypeError should have been raised')
+        except enforce.exceptions.RuntimeTypeError:
+            pass
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I've implemented a new recursive type parser to hopefully resolve issues #2 and #3. 

High level overview of the changes:
* Implemented recursive checker using private variables defined in the official `typing.py` source code.
* Added several tests to check the new behavior.
* Added support for callable argument annotation (e.g. `foo(fun: Callable[[int], int]) -> None`)

Some notes about this:
1. We assume that every level of an iterable type is annotated. If it isn't, an error will be raised.
2. Because *every item is checked*, it is not very efficient for large arrays or large nested structures of any time

Steps Forward:
* Add optimizations to quickly check nested structures
* Add numpy array support using dtype
* Add recursion level global value to limit how many levels deep we care about checking. Possibly may want to make the default behavior so that it only checks the first recursion level, basically yielding the current behavior.

Let me know if you want me to work on any of these changes before you consider my PR.

Will Farmer