### PR TITLE
Improvements on the Dev Branch

### DIFF
--- a/enforce/decorators.py
+++ b/enforce/decorators.py
@@ -109,6 +109,7 @@ def decorate(data, obj_instance=None):
                 if not validator.validate(result, 'return'):
                     exception_text = parse_errors(validator.errors, argument_hints, True)
                     raise RuntimeTypeError(exception_text)
+            # we *only* return result if all type checks passed
             return result
 
         exception_text = parse_errors(validator.errors, argument_hints)
@@ -117,12 +118,14 @@ def decorate(data, obj_instance=None):
     return wrapper
 
 
-def get_validator(func: typing.Callable, hints: typing.Dict, instance=None):
+def get_validator(func: typing.Callable, hints: typing.Dict, instance: typing.Optional[typing.Any]=None):
     """
     Checks if the function was already decorated with a type checker
     Returns new validator if it was not and creates a new attribute in the passed function
     with a new validator.
     Otherwise, returns None
+
+    TODO: Add type hinting for instance argument
     """
     if instance:
         func = instance
@@ -137,7 +140,7 @@ def get_validator(func: typing.Callable, hints: typing.Dict, instance=None):
         return func.__validator__
 
 
-def init_validator(hints: typing.Dict):
+def init_validator(hints: typing.Dict) -> Parser:
     """
     Returns a new validator instance from a given dictionary of type hints
     """
@@ -146,13 +149,14 @@ def init_validator(hints: typing.Dict):
         if hint is None:
             hint = type(None)
         parser.parse(hint, name)
-    # DEBUG
+
+    # DEBUG printing to see the TypeTree
     print(str(parser))
 
     return parser.validator
 
 
-def parse_errors(errors, hints, return_type=False):
+def parse_errors(errors: typing.List[str], hints:typing.Dict[str, type], return_type: bool=False) -> str:
     """
     Generates an exception message based on which fields failed
     """

--- a/enforce/decorators.py
+++ b/enforce/decorators.py
@@ -74,6 +74,7 @@ def decorate(data, obj_instance=None):
 
     func_signature = inspect.signature(data)
 
+    # Argument hints is dict with str keys -> value types and 'return' -> type
     argument_hints = typing.get_type_hints(data)
 
     validator = get_validator(data, argument_hints, obj_instance)
@@ -95,12 +96,14 @@ def decorate(data, obj_instance=None):
         binded_arguments.apply_defaults()
 
         for name in argument_hints.keys():
+            # First, check argument types (every key not labelled 'return')
             if name != 'return':
                 argument = binded_arguments.arguments.get(name)
                 if not validator.validate(argument, name):
                     break
                 binded_arguments.arguments[name] = validator.data_out[name]
         else:
+            # Second, check return types
             result = data(*binded_arguments.args, **binded_arguments.kwargs)
             if 'return' in argument_hints.keys():
                 if not validator.validate(result, 'return'):
@@ -143,6 +146,8 @@ def init_validator(hints: typing.Dict):
         if hint is None:
             hint = type(None)
         parser.parse(hint, name)
+    # DEBUG
+    print(str(parser))
 
     return parser.validator
 

--- a/enforce/nodes.py
+++ b/enforce/nodes.py
@@ -24,6 +24,8 @@ class BaseNode(ABC):
     def validate(self, data, validator, force=False):
         valid = self.validate_data(validator, data, force)
 
+        print('\t{} - {} - {}'.format(data, self.data_type, valid))
+
         if not valid:
             yield False
             return
@@ -34,6 +36,7 @@ class BaseNode(ABC):
         # Not using zip because it will silence a mismatch in sizes
         # between children and propagated_data
         # And, for now, at least, I'd prefer it be explicit
+        # Note, if len(self.children) changes during iteration, errors *will* occur
         for i, child in enumerate(self.children):
             result = yield child.validate(propagated_data[i], validator, self.type_var)
             results.append(result)
@@ -103,7 +106,12 @@ class SimpleNode(BaseNode):
         return result
 
     def map_data(self, validator, data):
-        return []
+        propagated_data = []
+        if isinstance(data, list):
+            # If it's a list we need to make child for every item in list
+            propagated_data = data
+            self.children *= len(data)
+        return propagated_data
 
     def reduce_data(self, validator, data, old_data):
         return old_data

--- a/enforce/nodes.py
+++ b/enforce/nodes.py
@@ -24,8 +24,6 @@ class BaseNode(ABC):
     def validate(self, data, validator, force=False):
         valid = self.validate_data(validator, data, force)
 
-        print('\t{} - {} - {}'.format(data, self.data_type, valid))
-
         if not valid:
             yield False
             return

--- a/enforce/parsers.py
+++ b/enforce/parsers.py
@@ -76,7 +76,11 @@ class Parser:
 
     def _parse_callable(self, node, hint, parser):
         new_node = yield nodes.CallableNode()
-        parser.validator.all_nodes.append(new_node)
+        # Add every argument as a child
+        for element in hint.__args__:
+            yield self._map_parser(new_node, element, parser)
+        # Add return type as child
+        yield self._map_parser(new_node, hint.__result__, parser)
         yield self._yield_parsing_result(node, new_node)
 
     def _parse_tuple(self, node, hint, parser):

--- a/enforce/parsers.py
+++ b/enforce/parsers.py
@@ -14,10 +14,18 @@ class Parser:
             typing.TypeVar: self._parse_type_var,
             typing.TupleMeta: self._parse_tuple,
             typing.GenericMeta: self._parse_generic,
+            typing.CallableMeta: self._parse_callable,
             complex: self._parse_complex,
             float: self._parse_float,
             bytes: self._parse_bytes
             }
+
+    def __str__(self):
+        nodes = []
+        for hint, tree in self.validator.roots.items():
+            nodes.append(str(tree))
+        repr = '[{}]'.format(', '.join(nodes))
+        return repr
 
     def parse(self, hint, hint_name):
         parsers = self._map_parser(None, hint, self)
@@ -63,6 +71,11 @@ class Parser:
 
         new_node = yield nodes.TypeVarNode()
         new_node.add_child(global_node)
+        parser.validator.all_nodes.append(new_node)
+        yield self._yield_parsing_result(node, new_node)
+
+    def _parse_callable(self, node, hint, parser):
+        new_node = yield nodes.CallableNode()
         parser.validator.all_nodes.append(new_node)
         yield self._yield_parsing_result(node, new_node)
 

--- a/enforce/validators.py
+++ b/enforce/validators.py
@@ -11,8 +11,11 @@ class Validator:
         self.all_nodes = []
 
     def validate(self, data, param_name):
-        validatiors = self._validate(self.roots[param_name], data)
-        result = visit(validatiors)
+        """
+        Validate Syntax Tree using generators
+        """
+        validators = self._validate(self.roots[param_name], data)
+        result = visit(validators)
         self.data_out[param_name] = self.roots[param_name].data_out
         if not result:
             self.errors.append(param_name)

--- a/enforce/validators.py
+++ b/enforce/validators.py
@@ -1,4 +1,6 @@
-﻿from .utils import visit
+﻿import typing
+from .utils import visit
+from .nodes import BaseNode
 
 
 class Validator:
@@ -10,9 +12,9 @@ class Validator:
         self.roots = {}
         self.all_nodes = []
 
-    def validate(self, data, param_name):
+    def validate(self, data: typing.Any, param_name: str) -> bool:
         """
-        Validate Syntax Tree using generators
+        Validate Syntax Tree of given function using generators
         """
         validators = self._validate(self.roots[param_name], data)
         result = visit(validators)
@@ -21,11 +23,11 @@ class Validator:
             self.errors.append(param_name)
         return result
 
-    def reset(self):
+    def reset(self) -> None:
         self.errors = []
         self.data_out = {}
         for node in self.all_nodes:
             node.reset()
 
-    def _validate(self, node, data):
+    def _validate(self, node: BaseNode, data: typing.Any) -> typing.Generator:
         yield node.validate(data, self)

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -374,13 +374,7 @@ class UnionTypesTests(unittest.TestCase):
         def test_func(x: typing.Union[float, typing.List[str]]) -> int:
             return 5
         @runtime_validation
-        def nest_func(
-                x: typing.Union[
-                    float,
-                    typing.List[
-                        typing.Union[
-                            str,
-                            int]]]) -> int:
+        def nest_func(x: typing.Union[float, typing.List[typing.Union[str, int]]]) -> int:
             return 5
         self.test_func = test_func
         self.nest_func = nest_func
@@ -454,20 +448,12 @@ class CallableTypesTests(unittest.TestCase):
         def test(func: typing.Callable[[int, int], int], x: int) -> int:
             return func(x, x)
         @runtime_validation
-        def test_list(
-                func: typing.Callable[
-                        [typing.Union[typing.List[typing.Any],
-                                      int]],
-                        int]) -> int:
+        def test_list(func: typing.Callable[[typing.Union[typing.List[typing.Any], int]],
+                                            int]) -> int:
             return func(5)
         @runtime_validation
-        def union(
-                func: typing.Callable[
-                        [typing.Union[
-                            float,
-                            int],
-                         typing.Optional[str]],
-                        int]) -> int:
+        def union(func: typing.Callable[[typing.Union[float, int], typing.Optional[str]],
+                                        int]) -> int:
             return func(5)
         self.test = test
         self.test_list = test_list


### PR DESCRIPTION
Tons of changes for the dev branch.

* Added some comments helping explain how the code works
* Added type hinting to some methods and functions
* Added around 20 additional tests for various `Union`, `List`, and `Callable` cases.
* `Callable` methods at this point *mostly* work, but still have issues with deep nesting, which is I think a part of how `Union` and `Tuple` behave.
* Using @RussBaz's code for the initial non-parameterized version of `Callable` nodes, I was able to extend to also deal with arguments in the TypeTree.
* Added `__str__` override in `Parser` and `BaseNode` for quick/easy debugging.

```python
print(parser)  # Will print the entire parsed TypeTree.
```

This mostly or completely resolves issues #6 and #8.

This work is not anywhere near done, however I wanted to submit this PR to get your thoughts on the work that I've done.