### PR TITLE
When passing a callable object to a Callable argument, validate on object.__call__ instead of object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,7 @@ __pycache__/
 .Python
 env/
 venv/
+venv*/
 build/
 develop-eggs/
 dist/

--- a/README.md
+++ b/README.md
@@ -92,7 +92,12 @@ def foo(a: typing.Callable[[int, int], str]) -> str:
 def bar(a: int, b: int) -> str:
     return str(a * b)
 
+class Baz:
+    def __call__(self, a: int, b: int) -> str:
+      return bar(a, b)
+
 foo(bar)
+foo(Baz())
 ```
 
 #### TypeVar and Generics

--- a/enforce/nodes.py
+++ b/enforce/nodes.py
@@ -319,7 +319,10 @@ class CallableNode(BaseNode):
         from .enforcers import Enforcer, apply_enforcer
 
         if not inspect.isfunction(data):
-            return data
+            if hasattr(data, '__call__'): # handle case where data is a callable object
+                data = data.__call__
+            else:
+                return data
 
         try:
             enforcer = data.__enforcer__
@@ -379,7 +382,7 @@ class GenericNode(BaseNode):
 
     def __init__(self, data_type, **kwargs):
         from .enforcers import Enforcer, GenericProxy
-        print(data_type)
+        #print(data_type)
         try:
             enforcer = data_type.__enforcer__
         except AttributeError:
@@ -391,7 +394,7 @@ class GenericNode(BaseNode):
             if not is_type_of_type(type(enforcer), Enforcer, covariant=covariant, contravariant=contravariant):
                 enforcer =  GenericProxy(data_type).__enforcer__
 
-        print(enforcer.signature)
+        #print(enforcer.signature)
 
         super().__init__(enforcer, is_sequence=True, type_var=False, **kwargs)
 

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -725,6 +725,13 @@ class CallableTypesTests(unittest.TestCase):
         with self.assertRaises(RuntimeTypeError):
             self.any_func_return('bad_input')
 
+    def test_good_callable_object(self):
+        """ Test that a callable object works """
+        class Good:
+            def __call__(self, x: int, y: int) -> int:
+                return int(x * y)
+        self.test(Good(), 5)
+
     def test_good_func_arg(self):
         """ Test that good arguments pass """
         def good(x: int, y: int) -> int:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,8 +1,27 @@
 import unittest
+from enforce.utils import visit
+from enforce.nodes import CallableNode
+from typing import Callable
 
 
 class NodesTests(unittest.TestCase):
     pass
+
+class CallableNodeTests(unittest.TestCase):
+    def setUp(self):
+        self.node = CallableNode(Callable[[int], int])
+
+    def test_callable_validates_function(self):
+        def add1(x: int) -> int:
+            return x+1
+        self.assertTrue(visit(self.node.validate(add1, '')))
+
+    def test_callable_validates_callable_object(self):
+        class AddOne:
+            def __call__(self, x: int) -> int:
+                return x+1
+
+        self.assertTrue(visit(self.node.validate(AddOne(), '')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ideally, an object that implements the `__call__` method should be usable in any place a regular function can be used. Right now, though, `runtime_validation` will not accept callable objects for a `Callable` argument. This fixes and adds tests. Since the change happens in `CallableNode` other type validations (for example, that you're passing in an object) are unaffected.

Example:

```
>>> from enforce import runtime_validation
>>> from typing import Callable
>>>
>>> class Foo:
...     def __call__(self, a: int) -> str:
...       return str(2*a)
...
>>> @runtime_validation
... def class_name(a: Foo) -> str:
...     return str(a.__class__)
...
>>> @runtime_validation
... def run_function(f: typing.Callable[[int], str], b: int) -> str:
...     return f(b)
...
>>> print(class_name(Foo())) # Foo() can be read as an object of class 'Foo'
<class '__main__.Foo'>
>>> print(run_function(Foo(), 5)) # Foo() can now also be read as a callable
10
```