### PR TITLE
If there is no 'return' annotation, return output instead of 'None'

### DIFF
--- a/enforce/enforcers.py
+++ b/enforce/enforcers.py
@@ -97,6 +97,8 @@ class Enforcer:
                 raise RuntimeTypeError(exception_text)
             else:
                 return self.validator.data_out['return']
+        else:
+            return output_data
 
     def reset(self):
         """

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -33,6 +33,15 @@ class GeneralTests(unittest.TestCase):
 
         self.assertEqual(example(1), 1)
 
+    def test_return_value_validation(self):
+        self.assertIsNone(self.sample_function('', None))
+
+        result = 0
+        with self.assertRaises(RuntimeTypeError):
+            result += self.sample_function('', 1)
+
+        self.assertEqual(result, 0)
+
     def test_no_type_check(self):
         """
         Verifies that no_type_check is respected

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -22,14 +22,16 @@ class GeneralTests(unittest.TestCase):
 
         self.assertEqual(result, 0)
 
-    def test_return_value_validation(self):
-        self.assertIsNone(self.sample_function('', None))
+    def test_returns_output_if_no_return_annotation(self):
+        """
+        Verifies that the wrapped function's output is returned even if there
+        is no 'return' annotation
+        """
+        @runtime_validation
+        def example(x: int):
+            return x
 
-        result = 0
-        with self.assertRaises(RuntimeTypeError):
-            result += self.sample_function('', 1)
-
-        self.assertEqual(result, 0)
+        self.assertEqual(example(1), 1)
 
     def test_no_type_check(self):
         """


### PR DESCRIPTION
Setup:

```
from enforce import runtime_validation

@runtime_validation
def goofus(a: int):
  return a

@runtime_validation
def gallant(a: int) -> int:
  return a
```

Original behavior:

```
>>> print(gallant(1)) # ok
1
>>> print(goofus(1)) # bug
None
```

New behavior:

```
>>> print(goofus(1)) # ok now
1
```