### PR TITLE
Correct handling of None in TupleNode + Extended support from typing.List to typing.Iterable

### DIFF
--- a/enforce/nodes.py
+++ b/enforce/nodes.py
@@ -326,6 +326,12 @@ class TupleNode(BaseNode):
         super().__init__(typing.Tuple, is_sequence=True, is_container=True, **kwargs)
 
     def validate_data(self, validator, data, sticky=False):
+        # fix for https://github.com/RussBaz/enforce/issues/62 (1/4)
+        if data is None:
+            # unfortunately this is not enough to stop propagating to children...
+            # ... so the None case is also handled in map_data and validate_children
+            return ValidationResult(valid=False, data=data, type_name=extract_type_name(type(data)))
+
         covariant = self.covariant or validator.settings.covariant
         contravariant = self.contravariant or validator.settings.contravariant
 
@@ -341,7 +347,11 @@ class TupleNode(BaseNode):
             return ValidationResult(valid=False, data=data, type_name=extract_type_name(input_type))
 
     def validate_children(self, validator, propagated_data):
-        if self.variable_length:
+        # fix for https://github.com/RussBaz/enforce/issues/62 (3/4)
+        if propagated_data is None:
+            # yield a sequence of one element: a single failure
+            yield [ValidationResult(valid=False, data=propagated_data, type_name=extract_type_name(propagated_data))]
+        elif self.variable_length:
             child = self.children[0]
 
             children_validation_results = []
@@ -356,10 +366,14 @@ class TupleNode(BaseNode):
 
     def map_data(self, validator, self_validation_result):
         data = self_validation_result.data
-        output = []
-        for element in data:
-            output.append(element)
-        return output
+        # fix for https://github.com/RussBaz/enforce/issues/62 (2/4)
+        if data is not None:
+            output = []
+            for element in data:
+                output.append(element)
+            return output
+        else:
+            return None
 
     def reduce_data(self, validator, child_validation_results, self_validation_result):
         return tuple(result.data for result in child_validation_results)
@@ -369,12 +383,20 @@ class TupleNode(BaseNode):
         Returns a name of an actual type of given data
         """
         actual_type = self_validation_result.type_name
-        child_types = list(result.type_name for result in child_validation_results) or []
 
-        actual_type = TYPE_NAME_ALIASES.get(actual_type, actual_type)
+        # fix for https://github.com/RussBaz/enforce/issues/62 (4/4)
+        if actual_type == extract_type_name(type(None)):
+            # None - No need to check children
+            actual_type = TYPE_NAME_ALIASES.get(actual_type, actual_type)
 
-        if child_types:
-            actual_type = actual_type + '[' + ', '.join(child_types) + ']'
+        else:
+            # Append children type information
+            child_types = list(result.type_name for result in child_validation_results) or []
+
+            actual_type = TYPE_NAME_ALIASES.get(actual_type, actual_type)
+
+            if child_types:
+                actual_type = actual_type + '[' + ', '.join(child_types) + ']'
 
         return actual_type
 

--- a/enforce/parsers.py
+++ b/enforce/parsers.py
@@ -137,12 +137,15 @@ def _parse_bytes(node, hint, validator, parsers):
 
 
 def _parse_generic(node, hint, validator, parsers):
-    if issubclass(hint, typing.List):
-        yield _parse_list(node, hint, validator, parsers)
-    elif issubclass(hint, typing.Mapping):
-        yield _parse_dict(node, hint, validator, parsers)
-    elif issubclass(hint, typing.Set):
-        yield _parse_set(node, hint, validator, parsers)
+    # Fixes https://github.com/RussBaz/enforce/issues/{47, 51, 52}
+    # Mapping need to be checked BEFORE Iterable (since a Mapping is an Iterable)
+    if issubclass(hint, typing.Mapping):
+        yield _parse_mapping(node, hint, validator, parsers)
+    elif issubclass(hint, typing.Iterable):
+        yield _parse_iterable(node, hint, validator, parsers)
+    # Not needed anymore: a Set is just an Iterable
+    # elif issubclass(hint, typing.Set):
+    #     yield _parse_set(node, hint, validator, parsers)
     else:
         new_node = yield nodes.GenericNode(
             hint,
@@ -153,31 +156,32 @@ def _parse_generic(node, hint, validator, parsers):
         yield _yield_parsing_result(node, new_node)
 
 
-def _parse_list(node, hint, validator, parsers):
+def _parse_iterable(node, hint, validator, parsers):
     new_node = yield nodes.SimpleNode(hint.__extra__)
     validator.all_nodes.append(new_node)
 
     # add its type as child
-    # We need to index first element only as Lists always have 1 argument
+    # We need to index first element only as Iterable always have 1 argument
     if hint.__args__:
         yield get_parser(new_node, hint.__args__[0], validator, parsers)
 
     yield _yield_parsing_result(node, new_node)
 
 
-def _parse_set(node, hint, validator, parsers):
-    new_node = yield nodes.SimpleNode(hint.__extra__)
-    validator.all_nodes.append(new_node)
+# -- Not useful anymore: a Set is an Iterable
+# def _parse_set(node, hint, validator, parsers):
+#     new_node = yield nodes.SimpleNode(hint.__extra__)
+#     validator.all_nodes.append(new_node)
+#
+#     # add its type as child
+#     # We need to index first element only as Sets always have 1 argument
+#     if hint.__args__:
+#         yield get_parser(new_node, hint.__args__[0], validator, parsers)
+#
+#     yield _yield_parsing_result(node, new_node)
 
-    # add its type as child
-    # We need to index first element only as Sets always have 1 argument
-    if hint.__args__:
-        yield get_parser(new_node, hint.__args__[0], validator, parsers)
 
-    yield _yield_parsing_result(node, new_node)
-
-
-def _parse_dict(node, hint, validator, parsers):
+def _parse_mapping(node, hint, validator, parsers):
     hint_args = hint.__args__
 
     if hint_args:


### PR DESCRIPTION
Correct handling of None in TupleNode: Fixes #62.
-------------------------
You might wish to add corresponding unit tests: 

This should not raise an error anymore:

```python
from typing import Optional, Tuple
from enforce import runtime_validation

@runtime_validation
def foo(arg: Optional[Tuple[str, str]] = None):
    pass

foo()
```

While this should continue to raise an error as usual:

```python
from typing import Tuple
from enforce import runtime_validation

@runtime_validation
def foo(arg: Tuple[str, str]):
    pass


foo(None)
```

Extended support from typing.List to typing.Iterable (and Dict to Mapping)
-------------------------
Fixes #52, Fixes #51, fixes #47.

You might wish to include the following basic tests:

```python
from enforce import runtime_validation, config
from enforce.exceptions import RuntimeTypeError
config(dict(mode='covariant'))  # by the way, so sad that this is not the default :)


########## SEQUENCE / ITERABLE / SET / GENERATOR
from typing import Sequence, Iterable, Set, Generator

@runtime_validation
def seq(s: Sequence[str]):
    pass

@runtime_validation
def it(s: Iterable[str]):
    pass


seq(['a'])
# transform this into appropriate test handler
try:
    seq(['r', 1])
    raise Exception('failed!')
except RuntimeTypeError:
    pass

it(['a'])
# transform this into appropriate test handler
try:
    it(['r', 1])
    raise Exception('failed!')
except RuntimeTypeError:
    pass


@runtime_validation
def st(m: Set[int]):
    pass


st({2, 2})
# transform this into appropriate test handler
try:
    st({'r', 1})
    raise Exception('failed!')
except RuntimeTypeError:
    pass


@runtime_validation
def generator() -> Generator[int, None, None]:
    i = 0
    while True:
        if i == 0:
            yield i
        else:
            yield 'a string! it cannot be detected by enforce but thats a bit normal'
        i += 1


g = generator()
print(next(g))
print(next(g))


########## MAPPING
from typing import Mapping


@runtime_validation
def bar(m: Mapping[int, int]):
    pass


bar({2: 2})
# transform this into appropriate test handler
try:
    bar({'r': 1})
    raise Exception('failed!')
except RuntimeTypeError:
    pass
```

----------------------------


Note: the fix with Iterable can probably fail in some rare cases where users define a custom typing.GenericMeta type inheriting from typing.Iterable BUT having several inner generic arguments (like it is in typing.Mapping, that we currently handle correctly by handling it BEFORE other Iterables). Not sure that this case will happen soon :)
