### PR TITLE
Declare description as Markdown in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
 
     description='Python 3.5+ library for integration testing and data validation through configurable and optional runtime type hint enforcement.',
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
 
     url='https://github.com/RussBaz/enforce',
     author='RussBaz',


### PR DESCRIPTION
This will render the description correctly on the [PyPI page](https://pypi.org/project/enforce/), when you next do a release.

Docs: https://setuptools.pypa.io/en/latest/references/keywords.html?highlight=long_description#keywords